### PR TITLE
Remove <Widget> element

### DIFF
--- a/clockwork.yml
+++ b/clockwork.yml
@@ -1,3 +1,3 @@
 name: example-ui-pkg
-version: 1.0.0
+version: 2.0.0
 description: ''

--- a/text.xml
+++ b/text.xml
@@ -1,11 +1,9 @@
-<Widget>
-    <PartText name="TextComponent" alpha="255" height="100" pivotX="0.5" pivotY="0.5"
-        width="500" x="-50" y="0">
-        <Text align="CENTER">
-            <Font color="#ffffffff" family="SYNC_TO_DEVICE" size="40" slant="NORMAL"
-                weight="NORMAL">
-                Sample component
-            </Font>
-        </Text>
-    </PartText>
-</Widget>
+<PartText name="TextComponent" alpha="255" height="100" pivotX="0.5" pivotY="0.5"
+    width="500" x="-50" y="0">
+    <Text align="CENTER">
+        <Font color="#ffffffff" family="SYNC_TO_DEVICE" size="40" slant="NORMAL"
+            weight="NORMAL">
+            Sample component
+        </Font>
+    </Text>
+</PartText>


### PR DESCRIPTION
`<Widget>` is not compatible with, nor required by, xml-preprocessor 1.3+.